### PR TITLE
Security Patch: Parameter Pollution & Command Blacklist Bypass Fixes

### DIFF
--- a/bukkit/src/main/java/net/leaderos/plugin/modules/connect/ConnectModule.java
+++ b/bukkit/src/main/java/net/leaderos/plugin/modules/connect/ConnectModule.java
@@ -183,7 +183,7 @@ public class ConnectModule extends LeaderOSModule {
             }
 
             // Get the root command (the first word before space)
-            String commandRoot = command.split(" ")[0];
+            String commandRoot = command.split(" ")[0].toLowerCase();
 
             // Clean bukkit: prefix
             if (commandRoot.startsWith("bukkit:")) {
@@ -195,8 +195,16 @@ public class ConnectModule extends LeaderOSModule {
                 commandRoot = commandRoot.substring(10);
             }
 
-            // Check if the command is blacklisted
-            if (commandBlacklist.contains(commandRoot)) {
+            // Check if the command is blacklisted (case-insensitive now)
+            boolean isBlacklisted = false;
+            for (String blacklisted : commandBlacklist) {
+                if (blacklisted.toLowerCase().equals(commandRoot)) {
+                    isBlacklisted = true;
+                    break;
+                }
+            }
+
+            if (isBlacklisted) {
                 String msg = ChatUtil.replacePlaceholders(
                         Bukkit.getInstance().getLangFile().getMessages().getConnect().getCommandBlacklisted(),
                         new Placeholder("%command%", command)

--- a/bungee/src/main/java/net/leaderos/bungee/modules/connect/ConnectModule.java
+++ b/bungee/src/main/java/net/leaderos/bungee/modules/connect/ConnectModule.java
@@ -75,10 +75,25 @@ public class ConnectModule extends LeaderOSModule {
                     }
 
                     // Get the root command (the first word before space)
-                    String commandRoot = command.split(" ")[0];
+                    String commandRoot = command.split(" ")[0].toLowerCase();
+                    
+                    // Prefix check for safety
+                    if (commandRoot.startsWith("bukkit:")) {
+                        commandRoot = commandRoot.substring(7);
+                    } else if (commandRoot.startsWith("minecraft:")) {
+                        commandRoot = commandRoot.substring(10);
+                    }
 
-                    // Check if the command is blacklisted
-                    if (commandBlacklist.contains(commandRoot)) {
+                    // Check if the command is blacklisted (case-insensitive now)
+                    boolean isBlacklisted = false;
+                    for (String blacklisted : commandBlacklist) {
+                        if (blacklisted.toLowerCase().equals(commandRoot)) {
+                            isBlacklisted = true;
+                            break;
+                        }
+                    }
+
+                    if (isBlacklisted) {
                         String msg = ChatUtil.replacePlaceholders(
                                 Bungee.getInstance().getLangFile().getMessages().getConnect().getCommandBlacklisted(),
                                 new Placeholder("%command%", command)

--- a/shared/src/main/java/net/leaderos/shared/model/Request.java
+++ b/shared/src/main/java/net/leaderos/shared/model/Request.java
@@ -150,13 +150,13 @@ public abstract class Request {
                 if (encodedData.length() != 0) {
                     encodedData.append("&");
                 }
-                encodedData.append(entry.getKey());
+                encodedData.append(java.net.URLEncoder.encode(entry.getKey(), "UTF-8"));
                 encodedData.append("=");
-                encodedData.append(entry.getValue());
+                encodedData.append(java.net.URLEncoder.encode(entry.getValue(), "UTF-8"));
             }
             return encodedData.toString();
         }
-        catch (NullPointerException e) {
+        catch (NullPointerException | java.io.UnsupportedEncodingException e) {
             return null;
         }
     }

--- a/velocity/src/main/java/net/leaderos/velocity/modules/connect/ConnectModule.java
+++ b/velocity/src/main/java/net/leaderos/velocity/modules/connect/ConnectModule.java
@@ -75,10 +75,25 @@ public class ConnectModule extends LeaderOSModule {
                     }
 
                     // Get the root command (the first word before space)
-                    String commandRoot = command.split(" ")[0];
+                    String commandRoot = command.split(" ")[0].toLowerCase();
+                    
+                    // Prefix check for safety
+                    if (commandRoot.startsWith("bukkit:")) {
+                        commandRoot = commandRoot.substring(7);
+                    } else if (commandRoot.startsWith("minecraft:")) {
+                        commandRoot = commandRoot.substring(10);
+                    }
 
-                    // Check if the command is blacklisted
-                    if (commandBlacklist.contains(commandRoot)) {
+                    // Check if the command is blacklisted (case-insensitive now)
+                    boolean isBlacklisted = false;
+                    for (String blacklisted : commandBlacklist) {
+                        if (blacklisted.toLowerCase().equals(commandRoot)) {
+                            isBlacklisted = true;
+                            break;
+                        }
+                    }
+
+                    if (isBlacklisted) {
                         Component msg = ChatUtil.replacePlaceholders(
                                 Velocity.getInstance().getLangFile().getMessages().getConnect().getCommandBlacklisted(),
                                 new Placeholder("%command%", command)


### PR DESCRIPTION
This PR addresses two critical security vulnerabilities discovered in the plugin:

**1. HTTP Parameter Pollution (Critical)**
The `encodeFormData` method in `Request.java` previously concatenated parameters without URL encoding. This allowed attackers to inject parameters via item names, overwriting request values and manipulating the server economy via the Webstore/Bazaar APIs.
- **Fix:** Both keys and values are now wrapped with `java.net.URLEncoder.encode()`.

**2. Command Blacklist Bypass (Critical)**
The `ConnectModule` across Bukkit, Bungee, and Velocity checked the command blacklist strictly case-sensitively and failed to strip `bukkit:` or `minecraft:` prefixes universally. This allowed attackers bypassing the API to execute blacklisted commands.
- **Fix:** Added `.toLowerCase()` inside the verification loop and implemented prefix stripping on Bungee and Velocity to match Bukkit's safety measures.
